### PR TITLE
Out of bounds

### DIFF
--- a/beampower/__init__.py
+++ b/beampower/__init__.py
@@ -11,4 +11,4 @@ __all__ = ["load_library", "beamform"]
 from .core import load_library
 from .beampower import beamform
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/beampower/beampower.py
+++ b/beampower/beampower.py
@@ -14,6 +14,7 @@ def beamform(
     device="cpu",
     reduce="max",
     mode="direct",
+    out_of_bounds="strict"
 ):
     """Compute the beamformed network response.
 
@@ -62,6 +63,15 @@ def beamform(
         If `reduce` is `'max'`, return the maximum network response source
         indexes.
     """
+    if out_of_bounds not in ["strict", "flexible"]:
+        print("out_of_bounds should be either of 'strict' or 'flexible',"
+                f" not {out_of_bounds}")
+        return
+    elif out_of_bounds == "strict":
+        out_of_bounds = 0
+    elif out_of_bounds == "flexible":
+        out_of_bounds = 1
+
     # Load library
     lib = load_library(device)
 
@@ -111,6 +121,7 @@ def beamform(
                     n_sources,
                     n_stations,
                     n_phases,
+                    int(out_of_bounds),
                     beam.ctypes.data_as(ct.POINTER(ct.c_float)),
                 )
                 return beam.reshape(n_sources, n_samples)

--- a/beampower/beampower.py
+++ b/beampower/beampower.py
@@ -155,6 +155,7 @@ def beamform(
                     n_sources,
                     n_stations,
                     n_phases,
+                    int(out_of_bounds),
                     beam.ctypes.data_as(ct.POINTER(ct.c_float)),
                 )
                 return beam.reshape(n_sources, n_samples)
@@ -170,6 +171,7 @@ def beamform(
                     n_sources,
                     n_stations,
                     n_phases,
+                    int(out_of_bounds),
                     beam_max.ctypes.data_as(ct.POINTER(ct.c_float)),
                     beam_argmax.ctypes.data_as(ct.POINTER(ct.c_int)),
                 )

--- a/beampower/beampower.py
+++ b/beampower/beampower.py
@@ -137,6 +137,7 @@ def beamform(
                     n_sources,
                     n_stations,
                     n_phases,
+                    int(out_of_bounds),
                     beam_max.ctypes.data_as(ct.POINTER(ct.c_float)),
                     beam_argmax.ctypes.data_as(ct.POINTER(ct.c_int)),
                 )

--- a/beampower/core.py
+++ b/beampower/core.py
@@ -66,6 +66,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_sources
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
+            ct.c_int,  # out_of_bounds
             ct.POINTER(ct.c_float),  # beam
         ],
         "beamform_max_argtypes": [
@@ -76,6 +77,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_sources
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
+            ct.c_int,  # out_of_bounds
             ct.POINTER(ct.c_float),  # beam_max
             ct.POINTER(ct.c_int),  # beam_argmax
         ],

--- a/beampower/core.py
+++ b/beampower/core.py
@@ -19,6 +19,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_sources
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
+            ct.c_int,  # out_of_bounds
             ct.POINTER(ct.c_float),  # beam
         ],
         "beamform_differential_argtypes": [

--- a/beampower/core.py
+++ b/beampower/core.py
@@ -32,7 +32,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_phases
             ct.POINTER(ct.c_float),  # beam
         ],
-        "beamform_argmax_argtypes": [
+        "beamform_max_argtypes": [
             ct.POINTER(ct.c_float),  # waveform_features
             ct.POINTER(ct.c_int),  # time_delays
             ct.POINTER(ct.c_float),  # weights_sources
@@ -40,6 +40,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_sources
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
+            ct.c_int,  # out_of_bounds
             ct.POINTER(ct.c_float),  # beam_max
             ct.POINTER(ct.c_int),  # beam_argmax
         ],
@@ -67,7 +68,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_phases
             ct.POINTER(ct.c_float),  # beam
         ],
-        "beamform_argmax_argtypes": [
+        "beamform_max_argtypes": [
             ct.POINTER(ct.c_float),  # waveform_features
             ct.POINTER(ct.c_int),  # time_delays
             ct.POINTER(ct.c_float),  # weights_sources
@@ -118,7 +119,7 @@ def load_library(device="cpu"):
 
             # Declare types
             lib.beamform.argtypes = library_info["beamform_argtypes"]
-            lib.beamform_max.argtypes = library_info["beamform_argmax_argtypes"]
+            lib.beamform_max.argtypes = library_info["beamform_max_argtypes"]
             if device_name == "cpu":
                 lib.prestack_waveform_features.argtypes = library_info[
                     "prestack_waveform_features_argtypes"

--- a/beampower/src/beamform.c
+++ b/beampower/src/beamform.c
@@ -71,6 +71,40 @@ float _beam(float *waveform_features, int *time_delays, float *weights,
     return beam;
 }
 
+float _beam_check_out_of_bounds(
+        float *waveform_features, int *time_delays, float *weights,
+        size_t time_index, size_t n_samples, size_t n_stations, size_t n_phases
+        )
+{
+
+    /* Build a beam of the detection traces using the input time_delays.
+     * It checks whether t + time_delay[s, p] is out of bound for each
+     * station and phase.
+     * This routine uses the detection traces prestacked for each phase. */
+
+    float beam = 0.;      // shifted and stacked traces
+    size_t feature_offset; // position on input pointer
+    size_t max_offet;
+
+    for (size_t s = 0; s < n_stations; s++)
+    {
+        if (weights[s] == 0)
+            continue;
+        // station loop
+        for (size_t p = 0; p < n_phases; p++)
+        {
+            // check out-of-bounds
+            if (time_index + time_delays[s * n_phases + p] >= n_samples) continue;
+            if (time_index + time_delays[s * n_phases + p] < 0) continue;
+            // phase loop
+            feature_offset = s * n_samples * n_phases + p + n_phases * time_delays[s * n_phases + p];
+            beam += weights[s] * waveform_features[feature_offset];
+        }
+    }
+    return beam;
+}
+
+
 void prestack_waveform_features(
     float *waveform_features, float *weights_phases,
     size_t n_samples, size_t n_stations, size_t n_channels,
@@ -115,7 +149,7 @@ void prestack_waveform_features(
 
 void beamform(float *waveform_features, int *time_delays, float *weights,
               size_t n_samples, size_t n_sources, size_t n_stations,
-              size_t n_phases, float *beam)
+              size_t n_phases, int out_of_bounds, float *beam)
 {
 
     /* Compute the beamformed network response at each input theoretical source
@@ -151,19 +185,36 @@ void beamform(float *waveform_features, int *time_delays, float *weights,
         time_delay_max = time_delays_minmax[2 * i + 1];
         for (int t = 0; t < n_samples; t++)
         {
-            // check out-of-bound operations
-            if ((t + time_delay_max) >= n_samples)
-                continue;
-            if ((t + time_delay_min) < 0)
-                continue;
+            if (out_of_bounds == 0){
+                // check out-of-bound operations for the whole network
+                if ((t + time_delay_max) >= n_samples)
+                    continue;
+                if ((t + time_delay_min) < 0)
+                    continue;
 
-            // compute the beamformed network responses for all sources
-            beam[beam_offset + t] = _beam(waveform_features + n_phases * t,
-                                          time_delays + time_delay_offset,
-                                          weights + weights_offset,
-                                          n_samples,
-                                          n_stations,
-                                          n_phases);
+                // compute the beamformed network responses for all sources
+                beam[beam_offset + t] = _beam(waveform_features + n_phases * t,
+                                              time_delays + time_delay_offset,
+                                              weights + weights_offset,
+                                              n_samples,
+                                              n_stations,
+                                              n_phases);
+
+                }
+            else if (out_of_bounds == 1){
+                // check out-of-bound operations separately for each station
+                //
+                // compute the beamformed network responses for all sources
+                beam[beam_offset + t] = _beam_check_out_of_bounds(
+                        waveform_features + n_phases * t,
+                        time_delays + time_delay_offset,
+                        weights + weights_offset,
+                        t,
+                        n_samples,
+                        n_stations,
+                        n_phases
+                        );
+            }
         }
     }
 }

--- a/beampower/src/beamform_cpu.h
+++ b/beampower/src/beamform_cpu.h
@@ -1,6 +1,7 @@
 void _find_minmax_time_delays(int *, float *, size_t, size_t, size_t, int *);
 float _beam(float *, int *, float *, size_t, size_t, size_t);
+float _beam_check_out_of_bounds(float *, int *, float *, size_t, size_t, size_t, size_t);
 void prestack_waveform_features(float *, float *, size_t, size_t, size_t, size_t, float *);
-void beamform(float *, int *, float *, size_t, size_t, size_t, size_t, float *);
+void beamform(float *, int *, float *, size_t, size_t, size_t, size_t, int, float *);
 void beamform_differential(float *, int *, float *, size_t, size_t, size_t, size_t, float *);
 void beamform_max(float *, int *, float *, size_t, size_t, size_t, size_t, float *, int *);

--- a/beampower/src/beamform_cpu.h
+++ b/beampower/src/beamform_cpu.h
@@ -4,4 +4,4 @@ float _beam_check_out_of_bounds(float *, int *, float *, size_t, size_t, size_t,
 void prestack_waveform_features(float *, float *, size_t, size_t, size_t, size_t, float *);
 void beamform(float *, int *, float *, size_t, size_t, size_t, size_t, int, float *);
 void beamform_differential(float *, int *, float *, size_t, size_t, size_t, size_t, float *);
-void beamform_max(float *, int *, float *, size_t, size_t, size_t, size_t, float *, int *);
+void beamform_max(float *, int *, float *, size_t, size_t, size_t, size_t, int, float *, int *);

--- a/beampower/src/beamform_gpu.h
+++ b/beampower/src/beamform_gpu.h
@@ -1,2 +1,2 @@
-void beamform(float*, int*, float*, size_t, size_t, size_t, size_t, float*);
-void beamform_max(float*, int*, float*, size_t, size_t, size_t, size_t, float*, int*);
+void beamform(float*, int*, float*, size_t, size_t, size_t, size_t, int, float*);
+void beamform_max(float*, int*, float*, size_t, size_t, size_t, size_t, int, float*, int*);

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="beampower",
-    version="1.0.1",
+    version="1.0.2",
     author="Eric Beauce, William B. Frank, Leonard Seydoux",
     author_email="ebeauce@ldeo.columbia.edu",
     description="Package for beamforming/backprojection.",


### PR DESCRIPTION
A new key-word argument is available: out_of_bounds. It is either of "strict" (default, which is the same behavior as previous implementation) and "flexible". The "flexible" option lets a beam be computed even if the moveouts of some of the stations point outside of the data vector (that is, towards the end of the data vector). These out-of-bound stations are simply not included in the beam, resulting in a beam that is strictly smaller than what the beam would be with all stations. Thus, it does not induce false detections. However, this behavior might be desired when processing short chunks of data like in (near) real-time applications.