### PR TITLE
Num threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,11 @@ LDFLAGS_CPU=-shared
 # GPU FLAGS
 COPTIMFLAGS_GPU=-O3
 CFLAGS_GPU=-Xcompiler "-fopenmp -fPIC -march=native -ftree-vectorize" -Xlinker -lgomp
-ARCHFLAG=-gencode arch=compute_35,code=sm_35\
-         -gencode arch=compute_70,code=sm_70\
+ARCHFLAG=-gencode arch=compute_70,code=sm_70\
          -gencode arch=compute_75,code=sm_75\
-         -gencode arch=compute_80,code=sm_80
+         -gencode arch=compute_80,code=sm_80\
+         #-gencode arch=compute_35,code=sm_35\
+
 LDFLAGS_GPU=--shared
 
 # build

--- a/beampower/beampower.py
+++ b/beampower/beampower.py
@@ -4,6 +4,7 @@ import ctypes as ct
 import numpy as np
 
 from .core import load_library
+from os import cpu_count
 
 
 def beamform(
@@ -79,7 +80,7 @@ def beamform(
     if num_threads is None:
         # set num_threads to -1 so that the C routine
         # understands to use all CPUs
-        num_threads = -1
+        num_threads = cpu_count()
 
     # Load library
     lib = load_library(device)
@@ -102,7 +103,7 @@ def beamform(
 
     # Prestack detection traces
     waveform_features = prestack_traces(
-        waveform_features, weights_phases, device="cpu"
+        waveform_features, weights_phases, num_threads=num_threads, device="cpu"
     )
 
     # Get waveform features
@@ -258,6 +259,9 @@ def prestack_traces(waveform_features, weights_phases, num_threads=None, device=
     # Load library
     lib = load_library(device)
 
+    if num_threads is None:
+        num_threads = cpu_count()
+
     # Get shapes
     n_stations, n_channels, n_samples = waveform_features.shape
     _, _, n_phases = weights_phases.shape
@@ -278,7 +282,7 @@ def prestack_traces(waveform_features, weights_phases, num_threads=None, device=
             n_stations,
             n_channels,
             n_phases,
-            num_threads,
+            int(num_threads),
             prestacked_traces.ctypes.data_as(ct.POINTER(ct.c_float)),
         )
 

--- a/beampower/core.py
+++ b/beampower/core.py
@@ -20,6 +20,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
             ct.c_int,  # out_of_bounds
+            ct.c_int,  # num_threads
             ct.POINTER(ct.c_float),  # beam
         ],
         "beamform_differential_argtypes": [
@@ -30,6 +31,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_sources
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
+            ct.c_int,  # num_threads
             ct.POINTER(ct.c_float),  # beam
         ],
         "beamform_max_argtypes": [
@@ -41,6 +43,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_phases
             ct.c_int,  # out_of_bounds
+            ct.c_int,  # num_threads
             ct.POINTER(ct.c_float),  # beam_max
             ct.POINTER(ct.c_int),  # beam_argmax
         ],
@@ -51,6 +54,7 @@ LIBRARIES = {
             ct.c_size_t,  # n_stations
             ct.c_size_t,  # n_channels
             ct.c_size_t,  # n_phases
+            ct.c_int,  # num_threads
             ct.POINTER(ct.c_float),  # prestacked_traces
         ],
     },

--- a/beampower/src/beamform.c
+++ b/beampower/src/beamform.c
@@ -108,7 +108,7 @@ float _beam_check_out_of_bounds(
 void prestack_waveform_features(
     float *waveform_features, float *weights_phases,
     size_t n_samples, size_t n_stations, size_t n_channels,
-    size_t n_phases, float *prestack_traces)
+    size_t n_phases, int num_threads, float *prestack_traces)
 {
 
     /* The channel dimension can be reduced ahead of the beamforming
@@ -118,6 +118,10 @@ void prestack_waveform_features(
     size_t prestack_offset;
     size_t feature_offset;
     size_t weight_offset;
+
+    if (num_threads != -1){
+        omp_set_num_threads(num_threads);
+    }
 
 #pragma omp parallel for private(prestack_offset, feature_offset, weight_offset) \
     shared(waveform_features, weights_phases, prestack_traces)
@@ -149,7 +153,7 @@ void prestack_waveform_features(
 
 void beamform(float *waveform_features, int *time_delays, float *weights,
               size_t n_samples, size_t n_sources, size_t n_stations,
-              size_t n_phases, int out_of_bounds, float *beam)
+              size_t n_phases, int out_of_bounds, int num_threads, float *beam)
 {
 
     /* Compute the beamformed network response at each input theoretical source
@@ -164,6 +168,10 @@ void beamform(float *waveform_features, int *time_delays, float *weights,
     size_t beam_offset;       // location on beam
     int *time_delays_minmax;  // vector with min and max mv of each source
     int time_delay_min, time_delay_max;
+
+    if (num_threads != -1){
+        omp_set_num_threads(num_threads);
+    }
 
     // search for min and max time_delay of each source
     time_delays_minmax = (int *)malloc(2 * n_sources * sizeof(int));
@@ -222,7 +230,8 @@ void beamform(float *waveform_features, int *time_delays, float *weights,
 void beamform_max(
     float *waveform_features, int *time_delays, float *weights,
     size_t n_samples, size_t n_sources, size_t n_stations,
-    size_t n_phases, int out_of_bounds, float *beam, int *source_index_beam)
+    size_t n_phases, int out_of_bounds, int num_threads,
+    float *beam, int *source_index_beam)
 {
 
     /* Compute the beamformed network response at each input theoretical source
@@ -239,6 +248,10 @@ void beamform_max(
     float current_beam;       // value of currently computed beam
     float largest_beam;       // current largest visited beam
     int largest_beam_index;   // source index of current largest visited beam
+
+    if (num_threads != -1){
+        omp_set_num_threads(num_threads);
+    }
 
     // search for min and max time_delay of each source
     time_delays_minmax = (int *)malloc(2 * n_sources * sizeof(int));
@@ -324,7 +337,7 @@ void beamform_max(
 
 void beamform_differential(float *waveform_features, int *time_delays, float *weights,
                            size_t n_samples, size_t n_sources, size_t n_stations,
-                           size_t n_phases, float *beam)
+                           size_t n_phases, int num_threads, float *beam)
 {
 
     /* Compute the beamformed network response at each input theoretical source
@@ -340,6 +353,10 @@ void beamform_differential(float *waveform_features, int *time_delays, float *we
     int t = (n_samples - 1) / 2; // location or zero-lag
     int *time_delays_minmax;     // vector with min and max mv of each source
     int time_delay_min, time_delay_max;
+
+    if (num_threads != -1){
+        omp_set_num_threads(num_threads);
+    }
 
     // search for min and max time_delay of each source
     time_delays_minmax = (int *)malloc(2 * n_sources * sizeof(int));

--- a/beampower/src/beamform.cu
+++ b/beampower/src/beamform.cu
@@ -416,8 +416,8 @@ void beamform_max(
         gpuErrchk(cudaDeviceSynchronize());
 
         // critical section to merge all the single-GPU beam_max into one
-        for (size_t t=0; t<n_samples; t++){
 #pragma omp critical
+        for (size_t t=0; t<n_samples; t++){
             {
                 if (beam_max_thread[t] > beam_max[t]){
                     beam_max[t] = beam_max_thread[t];

--- a/beampower/src/beamform_cpu.h
+++ b/beampower/src/beamform_cpu.h
@@ -1,7 +1,7 @@
 void _find_minmax_time_delays(int *, float *, size_t, size_t, size_t, int *);
 float _beam(float *, int *, float *, size_t, size_t, size_t);
 float _beam_check_out_of_bounds(float *, int *, float *, size_t, size_t, size_t, size_t);
-void prestack_waveform_features(float *, float *, size_t, size_t, size_t, size_t, float *);
-void beamform(float *, int *, float *, size_t, size_t, size_t, size_t, int, float *);
-void beamform_differential(float *, int *, float *, size_t, size_t, size_t, size_t, float *);
-void beamform_max(float *, int *, float *, size_t, size_t, size_t, size_t, int, float *, int *);
+void prestack_waveform_features(float *, float *, size_t, size_t, size_t, size_t, int, float *);
+void beamform(float *, int *, float *, size_t, size_t, size_t, size_t, int, int, float *);
+void beamform_differential(float *, int *, float *, size_t, size_t, size_t, size_t, int, float *);
+void beamform_max(float *, int *, float *, size_t, size_t, size_t, size_t, int, int, float *, int *);


### PR DESCRIPTION
I'm introducing the "num_threads" key-word argument. It sets explicitly the number of threads used by openMP, which is very useful when running beampower without a job scheduler that conveniently assigns a limited number of cores to your jobs. For now, this new feature is only useful for the CPU implementation.

In the GPU implementation, the number of threads is set to the number of GPUs. I don't know if it's very useful to add a new key-work argument "num_gpus" because if you're sharing a machine with multiple GPUs, what you really need is to request those GPUs that are not being used by others. Thus, it would make more sense to give a list of GPU ids rather than just a number, but it's more complicated to code. Suggestions welcome!! (the same goes for FMF)